### PR TITLE
Fix typo in geonkick.desktop

### DIFF
--- a/data/geonkick.desktop
+++ b/data/geonkick.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=1.10
+Version=1.1
 MimeType=application/x-geonkick-preset;
 Name=Geonkick
 GenericName=Percussion Synthesizer


### PR DESCRIPTION
There is no Desktop Entry Specification 1.10 yet, so why conform to it?